### PR TITLE
Fix unit test run

### DIFF
--- a/nodewatcher/settings.py
+++ b/nodewatcher/settings.py
@@ -417,6 +417,9 @@ REGISTRY_RULES_MODULES = {
     'node.config': 'nodewatcher.rules',
 }
 
+# Disable South migrations during unit tests as they will fail
+SOUTH_TESTS_MIGRATE = False
+
 # In general, use https when constructing full URLs to nodewatcher?
 # Django's is_secure is used in the code as well. See SECURE_PROXY_SSL_HEADER configuration option.
 USE_HTTPS = False


### PR DESCRIPTION
Command `python manage.py test` currently fails. South migrations should be disabled during tests. Tests of some external Django apps are still failing though (`guardian`, `sekizai`, `django-missing`, `django.contrib.auth`).
