### PR TITLE
Add Xiaomi router Mini and Nano device descriptors

### DIFF
--- a/nodewatcher/modules/devices/cgm.py
+++ b/nodewatcher/modules/devices/cgm.py
@@ -1,3 +1,3 @@
 # Load supported devices.
 from . import fon, linksys, buffalo, mikrotik, asus, tplink, ubnt, siemens, glinet, ligowave, generic
-from . import raspberrypi, mqmaker, irnas
+from . import raspberrypi, mqmaker, irnas, xiaomi

--- a/nodewatcher/modules/devices/xiaomi/__init__.py
+++ b/nodewatcher/modules/devices/xiaomi/__init__.py
@@ -1,0 +1,2 @@
+# Xiaomi device modules.
+from . import mi_router

--- a/nodewatcher/modules/devices/xiaomi/mi_router.py
+++ b/nodewatcher/modules/devices/xiaomi/mi_router.py
@@ -1,0 +1,199 @@
+from django.utils.translation import ugettext_lazy as _
+
+from nodewatcher.core.generator.cgm import base as cgm_base, protocols as cgm_protocols, devices as cgm_devices
+
+
+class XiaomiMiMini(cgm_devices.DeviceBase):
+    """
+    Xiaomi Router Mini device descriptor.
+    """
+
+    identifier = 'mi-router-mini'
+    name = "Xiaomi Router Mini"
+    manufacturer = "Xiaomi"
+    url = 'http://miwifi.com/'
+    architecture = 'ramips_mt7620'
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio (5 GHz)"), [
+            cgm_protocols.IEEE80211AC(
+                cgm_protocols.IEEE80211AC.SHORT_GI_20,
+                cgm_protocols.IEEE80211AC.SHORT_GI_40,
+                cgm_protocols.IEEE80211AC.RX_STBC1,
+                cgm_protocols.IEEE80211AC.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna1")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ]),
+        cgm_devices.IntegratedRadio('wifi1', _("Integrated wireless radio (2.4 GHz)"), [
+            cgm_protocols.IEEE80211BGN(
+                cgm_protocols.IEEE80211BGN.SHORT_GI_20,
+                cgm_protocols.IEEE80211BGN.SHORT_GI_40,
+                cgm_protocols.IEEE80211BGN.RX_STBC1,
+                cgm_protocols.IEEE80211BGN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a2', "Antenna2")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = [
+        cgm_devices.Switch(
+            'sw0', "Switch0",
+            ports=[0, 1, 2, 3, 4, 6],
+            cpu_port=6,
+            cpu_tagged=True,
+            vlans=16,
+            configurable=True,
+            presets=[
+                cgm_devices.SwitchPreset('default', _("Default VLAN configuration"), vlans=[
+                    cgm_devices.SwitchVLANPreset(
+                        'wan0', "Wan0",
+                        vlan=2,
+                        ports=[4, 6],
+                    ),
+                    cgm_devices.SwitchVLANPreset(
+                        'lan0', "Lan0",
+                        vlan=1,
+                        ports=[0, 1, 2, 3, 6],
+                    ),
+                ])
+            ]
+        ),
+    ]
+    ports = []
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='dual',
+            angle_horizontal=360,
+            angle_vertical=360,
+            gain=3,
+        ),
+        cgm_devices.InternalAntenna(
+            identifier='a2',
+            polarization='dual',
+            angle_horizontal=360,
+            angle_vertical=360,
+            gain=3,
+        )
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'wifi1': 'radio1',
+            'sw0': cgm_devices.SwitchPortMap('switch0', vlans='eth0.{vlan}'),
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211',
+            'wifi1': 'mac80211',
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'miwifi-mini',
+            'files': [
+                '*-mt7620-generic-miwifi-mini-squashfs-sysupgrade.bin',
+            ]
+        }
+    }
+
+
+class XiaomiMiNano(cgm_devices.DeviceBase):
+    """
+    Xiaomi Router Nano device descriptor.
+    """
+
+    identifier = 'mi-router-nano'
+    name = "Xiaomi Router Nano"
+    manufacturer = "Xiaomi"
+    url = 'http://miwifi.com/'
+    architecture = 'ramips_mt7628'
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio"), [
+            cgm_protocols.IEEE80211BGN(
+                cgm_protocols.IEEE80211BGN.SHORT_GI_40,
+                cgm_protocols.IEEE80211BGN.TX_STBC1,
+                cgm_protocols.IEEE80211BGN.RX_STBC1,
+                cgm_protocols.IEEE80211BGN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna0")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = [
+        cgm_devices.Switch(
+            'sw0', "Switch0",
+            ports=[0, 1, 2, 3, 4, 6],
+            cpu_port=6,
+            cpu_tagged=True,
+            vlans=16,
+            configurable=True,
+            presets=[
+                cgm_devices.SwitchPreset('default', _("Default VLAN configuration"), vlans=[
+                    cgm_devices.SwitchVLANPreset(
+                        'wan0', "Wan0",
+                        vlan=2,
+                        ports=[4, 6],
+                    ),
+                    cgm_devices.SwitchVLANPreset(
+                        'lan0', "Lan0",
+                        vlan=1,
+                        ports=[0, 1, 2, 3, 6],
+                    ),
+                ])
+            ]
+        ),
+    ]
+    ports = []
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='horizontal',
+            angle_horizontal=360,
+            angle_vertical=360,
+            gain=3,
+        )
+    ]
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='horizontal',
+            angle_horizontal=360,
+            angle_vertical=75,
+            gain=2,
+        )
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'sw0': cgm_devices.SwitchPortMap('switch0', vlans='eth0.{vlan}'),
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211'
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'miwifi-nano',
+            'files': [
+                '*-mt7628-generic-miwifi-nano-squashfs-sysupgrade.bin',
+            ]
+        }
+    }
+
+
+# Register Xiaomi Mi router devices.
+cgm_base.register_device('lede', XiaomiMiMini)
+cgm_base.register_device('lede', XiaomiMiNano)


### PR DESCRIPTION
Hi,
another Pull request for adding new device descriptors.
This time support for Xiaomi router Mini and Nano.
Really good budget devices that outperform TP-Link at budget.
