### PR TITLE
devices: Remove factory binary and fix sysupgrade name in Edgerouter X

### DIFF
--- a/nodewatcher/modules/devices/ubnt/edgerouter.py
+++ b/nodewatcher/modules/devices/ubnt/edgerouter.py
@@ -49,8 +49,7 @@ class UBNTEdgerouterX(cgm_devices.DeviceBase):
         'lede': {
             'name': 'ubnt-erx',
             'files': [
-                '*-mt7621-generic-ubnt-erx-squashfs-factory.bin',
-                '*-mt7621-generic-ubnt-erx-squashfs-sysupgrade.bin',
+                '*-ramips-mt7621-ubnt-erx-squashfs-sysupgrade.tar',
             ]
         }
     }


### PR DESCRIPTION
Fixing my overlook in device descriptor for Edgerouter X.
Factory binary is not generated by default and therefore while building error occures.

Fixed by removing it from profiles in device descriptor