### PR TITLE
devices: Add Unifi AP AC Pro device descriptor

### DIFF
--- a/nodewatcher/modules/devices/ubnt/unifi.py
+++ b/nodewatcher/modules/devices/ubnt/unifi.py
@@ -83,6 +83,115 @@ class UBNTAPACLite(cgm_devices.DeviceBase):
     }
 
 
+class UBNTAPACPro(cgm_devices.DeviceBase):
+    """
+    Ubiquiti AP AC Pro device descriptor.
+    """
+
+    identifier = 'ub-uap-ac-pro'
+    name = "Unifi AP AC Pro"
+    manufacturer = "Ubiquiti"
+    url = 'http://www.ubnt.com/'
+    architecture = 'ar71xx'
+    usb = True
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio (5 GHz)"), [
+            cgm_protocols.IEEE80211AC(
+                cgm_protocols.IEEE80211AC.SHORT_GI_20,
+                cgm_protocols.IEEE80211AC.SHORT_GI_40,
+                cgm_protocols.IEEE80211AC.RX_STBC1,
+                cgm_protocols.IEEE80211AC.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna1")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ]),
+        cgm_devices.IntegratedRadio('wifi1', _("Integrated wireless radio (2.4 GHz)"), [
+            cgm_protocols.IEEE80211BGN(
+                cgm_protocols.IEEE80211BGN.SHORT_GI_20,
+                cgm_protocols.IEEE80211BGN.SHORT_GI_40,
+                cgm_protocols.IEEE80211BGN.RX_STBC1,
+                cgm_protocols.IEEE80211BGN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a2', "Antenna2")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = [
+        cgm_devices.Switch(
+            'sw0', "Gigabit switch",
+            ports=[0, 2, 3],
+            cpu_port=0,
+            cpu_tagged=True,
+            vlans=16,
+            configurable=True,
+            presets=[
+                cgm_devices.SwitchPreset('default', _("Default VLAN configuration"), vlans=[
+                    cgm_devices.SwitchVLANPreset(
+                        'wan0', "Wan0",
+                        vlan=2,
+                        ports=[0, 3],
+                    ),
+                    cgm_devices.SwitchVLANPreset(
+                        'lan0', "Lan0",
+                        vlan=1,
+                        ports=[0, 2],
+                    ),
+                ])
+            ]
+        ),
+    ]
+    ports = []
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='dual',
+            angle_horizontal=360,
+            angle_vertical=120,
+            gain=3,
+        ),
+        cgm_devices.InternalAntenna(
+            identifier='a2',
+            polarization='dual',
+            angle_horizontal=360,
+            angle_vertical=120,
+            gain=3,
+        ),
+        cgm_devices.InternalAntenna(
+            identifier='a3',
+            polarization='dual',
+            angle_horizontal=360,
+            angle_vertical=120,
+            gain=3,
+        )
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'wifi1': 'radio1',
+            'sw0': cgm_devices.SwitchPortMap('switch0', vlans='eth0.{vlan}'),
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211',
+            'wifi1': 'mac80211',
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'ubnt-unifiac-pro',
+            'files': [
+                '*-ar71xx-generic-ubnt-unifiac-pro-squashfs-sysupgrade.bin',
+            ]
+        }
+    }
+
+
 class UBNTUap(cgm_devices.DeviceBase):
     """
     UBNT Unifi UAP device descriptor.
@@ -153,5 +262,6 @@ class UBNTUapLR(UBNTUap):
 
 # Register Unifi AP devices.
 cgm_base.register_device('lede', UBNTAPACLite)
+cgm_base.register_device('lede', UBNTAPACPro)
 cgm_base.register_device('lede', UBNTUap)
 cgm_base.register_device('lede', UBNTUapLR)


### PR DESCRIPTION
Me again with another Unifi, this time it is AP AC Pro as @mitar suggested.
Building tested on local Nodewatcher and it builds without issues.

Unfortunately, I was not able to verify VLAN configuration on LEDE running on AP AC Pro as I don't have access to one.