### PR TITLE
Update OpenWRT default builders and add LEDE ar71xx builder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ influxdb:
 redis:
     image: tozd/redis
 builderar71xx:
-    image: wlanslovenija/openwrt-builder:v926b2fa_cc_ar71xx
+    image: wlanslovenija/openwrt-builder:v15acdee_cc_ar71xx
     environment:
         BUILDER_PUBLIC_KEY: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCho6FII0iKbpU+DpJqS9ARtn4jaXZAuc86QkaCc0FCKaaQh2QofgzTsibPICksyXfxRJM5rlEwwAf6RweGrtqM49pZGvmhS0fhoComGNC2qANDkAPlvAhs2JPp/jFeH7wDVUQr+D1Noc4daObddC7rrRtNa0ch9nAfYCTJcxSFp69VcUij9IX7O660w4CL2fL8ya/P43f2IZVqcFefPeY5/TydeE8GMZQo5L+7RKMR9rhZ4JY9CQbQgCkhl9IQ2Oc46dTDoUtxe556EWp3gqBRvd4CXcMlDS3jd1OvW5HHJLIgQ66uuS8C9I5VbzcpxpV+qfOxEeWXGRhd0V9H6/2n builder@wlan-si.net
         # To configure this builder in nodewatcher development instance,
@@ -52,7 +52,11 @@ builderar71xx:
         # BZ9HO5E5TUQTXTKkKR4kPT2wyfsjCBEJl76RIt7WyJnEbj1fIcn+OZo=
         # -----END RSA PRIVATE KEY-----
 builderlantiq:
-    image: wlanslovenija/openwrt-builder:v926b2fa_cc_lantiq
+    image: wlanslovenija/openwrt-builder:v15acdee_cc_lantiq
+    environment:
+        BUILDER_PUBLIC_KEY: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCho6FII0iKbpU+DpJqS9ARtn4jaXZAuc86QkaCc0FCKaaQh2QofgzTsibPICksyXfxRJM5rlEwwAf6RweGrtqM49pZGvmhS0fhoComGNC2qANDkAPlvAhs2JPp/jFeH7wDVUQr+D1Noc4daObddC7rrRtNa0ch9nAfYCTJcxSFp69VcUij9IX7O660w4CL2fL8ya/P43f2IZVqcFefPeY5/TydeE8GMZQo5L+7RKMR9rhZ4JY9CQbQgCkhl9IQ2Oc46dTDoUtxe556EWp3gqBRvd4CXcMlDS3jd1OvW5HHJLIgQ66uuS8C9I5VbzcpxpV+qfOxEeWXGRhd0V9H6/2n builder@wlan-si.net
+builderar71xx_lede:
+    image: wlanslovenija/lede-builder:v3ee8a65_17_01_1_ar71xx
     environment:
         BUILDER_PUBLIC_KEY: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCho6FII0iKbpU+DpJqS9ARtn4jaXZAuc86QkaCc0FCKaaQh2QofgzTsibPICksyXfxRJM5rlEwwAf6RweGrtqM49pZGvmhS0fhoComGNC2qANDkAPlvAhs2JPp/jFeH7wDVUQr+D1Noc4daObddC7rrRtNa0ch9nAfYCTJcxSFp69VcUij9IX7O660w4CL2fL8ya/P43f2IZVqcFefPeY5/TydeE8GMZQo5L+7RKMR9rhZ4JY9CQbQgCkhl9IQ2Oc46dTDoUtxe556EWp3gqBRvd4CXcMlDS3jd1OvW5HHJLIgQ66uuS8C9I5VbzcpxpV+qfOxEeWXGRhd0V9H6/2n builder@wlan-si.net
 generator:
@@ -70,6 +74,7 @@ generator:
         - redis
         - builderar71xx
         - builderlantiq
+        - builderar71xx_lede
 monitorq:
     build: .
     command: "scripts/docker-cleanup; scripts/docker-wait-pgsql; celery worker -A nodewatcher -l info -Q monitor -B --autoreload"
@@ -99,3 +104,4 @@ web:
         - redis
         - builderar71xx
         - builderlantiq
+        - builderar71xx_lede


### PR DESCRIPTION
Update OpenWRT builders included by default to docker-compose.yml and add LEDE ar71xx builder as one of defaults.