### PR TITLE
devices: Add TL-WR841N v12 device descriptor

### DIFF
--- a/nodewatcher/modules/devices/tplink/wr841nd.py
+++ b/nodewatcher/modules/devices/tplink/wr841nd.py
@@ -293,6 +293,24 @@ class TPLinkWR841NDv11(TPLinkWR841NDv7):
         }
     }
 
+
+class TPLinkWR841NDv12(TPLinkWR841NDv7):
+    """
+    TP-Link WR841NDv12 device descriptor.
+    """
+
+    identifier = 'tp-wr841ndv12'
+    name = "WR841ND (v12)"
+    profiles = {
+        'lede': {
+            'name': 'tl-wr841-v12',
+            'files': [
+                '*-ar71xx-generic-tl-wr841-v12-squashfs-factory.bin',
+                '*-ar71xx-generic-tl-wr841-v12-squashfs-sysupgrade.bin',
+            ]
+        }
+    }
+
 # Register the TP-Link WR841ND device.
 cgm_base.register_device('openwrt', TPLinkWR841NDv1)
 cgm_base.register_device('openwrt', TPLinkWR841NDv3)
@@ -302,3 +320,4 @@ cgm_base.register_device('openwrt', TPLinkWR841NDv8)
 cgm_base.register_device('openwrt', TPLinkWR841NDv9)
 cgm_base.register_device('openwrt', TPLinkWR841NDv10)
 cgm_base.register_device('openwrt', TPLinkWR841NDv11)
+cgm_base.register_device('lede', TPLinkWR841NDv12)


### PR DESCRIPTION
Adding device descriptor for TL-WRT841N v12 since it is now only version being sold.
It is identical to v11 and uses the same image but with the different identifier.
Support for it was added in LEDE v17.01.2