### PR TITLE
nodeupgrade: Customize to LEDE

### DIFF
--- a/nodewatcher/modules/services/nodeupgrade/frontend.py
+++ b/nodewatcher/modules/services/nodeupgrade/frontend.py
@@ -35,5 +35,5 @@ components.partials.get_partial('generator_view_build_partial').add(components.P
     name='nodeupgrade_lede',
     weight=100,
     visible=filter_platform('lede'),
-    template='nodeupgrade/build_result_openwrt.html',
+    template='nodeupgrade/build_result_lede.html',
 ))

--- a/nodewatcher/modules/services/nodeupgrade/templates/nodeupgrade/build_result_lede.html
+++ b/nodewatcher/modules/services/nodeupgrade/templates/nodeupgrade/build_result_lede.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<dt>{% trans "LEDE upgrade instructions" %}</dt>
+<dd>
+    {% blocktrans %}
+        If your node is already running a recent enough version of nodewatcher firmware, you may
+        perform the upgrade by running the following commands via SSH.
+    {% endblocktrans %}
+
+    <div class="code">$ nodeupgrade {{ build.pk }}</div>
+</dd>


### PR DESCRIPTION
Customize template to LEDE instead of using OpenWRT one.
That can cause confusion in some people