### PR TITLE
devices: Add multiple Mikrotik devices

### DIFF
--- a/nodewatcher/modules/devices/mikrotik/__init__.py
+++ b/nodewatcher/modules/devices/mikrotik/__init__.py
@@ -1,2 +1,2 @@
 # Mikrotik device modules.
-from . import rb2011, rb450, sxt, rbmap, rbwap
+from . import rb2011, rb450, sxt, rbmap, rbwap, rb912

--- a/nodewatcher/modules/devices/mikrotik/__init__.py
+++ b/nodewatcher/modules/devices/mikrotik/__init__.py
@@ -1,2 +1,2 @@
 # Mikrotik device modules.
-from . import rb2011, rb450
+from . import rb2011, rb450, sxt

--- a/nodewatcher/modules/devices/mikrotik/__init__.py
+++ b/nodewatcher/modules/devices/mikrotik/__init__.py
@@ -1,2 +1,2 @@
 # Mikrotik device modules.
-from . import rb2011, rb450, sxt, rbmap
+from . import rb2011, rb450, sxt, rbmap, rbwap

--- a/nodewatcher/modules/devices/mikrotik/__init__.py
+++ b/nodewatcher/modules/devices/mikrotik/__init__.py
@@ -1,2 +1,2 @@
 # Mikrotik device modules.
-from . import rb2011, rb450, sxt
+from . import rb2011, rb450, sxt, rbmap

--- a/nodewatcher/modules/devices/mikrotik/__init__.py
+++ b/nodewatcher/modules/devices/mikrotik/__init__.py
@@ -1,2 +1,2 @@
 # Mikrotik device modules.
-from . import rb2011, rb450, sxt, rbmap, rbwap, rb912
+from . import rb2011, rb450, sxt, rbmap, rbwap, rb912, lhg

--- a/nodewatcher/modules/devices/mikrotik/lhg.py
+++ b/nodewatcher/modules/devices/mikrotik/lhg.py
@@ -1,0 +1,66 @@
+from django.utils.translation import ugettext_lazy as _
+
+from nodewatcher.core.generator.cgm import base as cgm_base, protocols as cgm_protocols, devices as cgm_devices
+
+
+class MikrotikRBLHG_5nD(cgm_devices.DeviceBase):
+    """
+    Mikrotik RB LHG-5nD (LHG 5) device descriptor.
+    """
+
+    identifier = 'mt-rblhg-5nd'
+    name = "LHG 5 (RBLHG-5nD)"
+    manufacturer = "MikroTik"
+    url = 'https://mikrotik.com/product/RBLHG-5nD'
+    architecture = 'ar71xx_mikrotik'
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio"), [
+            cgm_protocols.IEEE80211AN(
+                cgm_protocols.IEEE80211AN.SHORT_GI_20,
+                cgm_protocols.IEEE80211AN.SHORT_GI_40,
+                cgm_protocols.IEEE80211AN.RX_STBC1,
+                cgm_protocols.IEEE80211AN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna0")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = []
+    ports = [
+        cgm_devices.EthernetPort('lan0', "Lan0")
+    ]
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='horizontal',
+            angle_horizontal=360,
+            angle_vertical=75,
+            gain=2,
+        )
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'lan0': 'eth0',
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211',
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'rb-nor-flash-16M',
+            'files': [
+                '*-ar71xx-mikrotik-rb-nor-flash-16M-squashfs-sysupgrade.bin',
+                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
+            ]
+        }
+    }
+
+# Register the Mikrotik LHG devices.
+cgm_base.register_device('lede', MikrotikRBLHG_5nD)

--- a/nodewatcher/modules/devices/mikrotik/lhg.py
+++ b/nodewatcher/modules/devices/mikrotik/lhg.py
@@ -57,7 +57,6 @@ class MikrotikRBLHG_5nD(cgm_devices.DeviceBase):
             'name': 'rb-nor-flash-16M',
             'files': [
                 '*-ar71xx-mikrotik-rb-nor-flash-16M-squashfs-sysupgrade.bin',
-                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
             ]
         }
     }

--- a/nodewatcher/modules/devices/mikrotik/rb912.py
+++ b/nodewatcher/modules/devices/mikrotik/rb912.py
@@ -32,6 +32,16 @@ class MikrotikRB912UAG_2HPnD(cgm_devices.DeviceBase):
     ports = [
         cgm_devices.EthernetPort('lan0', "Lan0")
     ]
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='horizontal',
+            angle_horizontal=360,
+            angle_vertical=75,
+            gain=2,
+        )
+    ]
     port_map = {
         'openwrt': {
             'wifi0': 'radio0',

--- a/nodewatcher/modules/devices/mikrotik/rb912.py
+++ b/nodewatcher/modules/devices/mikrotik/rb912.py
@@ -1,0 +1,57 @@
+from django.utils.translation import ugettext_lazy as _
+
+from nodewatcher.core.generator.cgm import base as cgm_base, protocols as cgm_protocols, devices as cgm_devices
+
+
+class MikrotikRB912UAG_2HPnD(cgm_devices.DeviceBase):
+    """
+    Mikrotik RB 912UAG-2HPnD device descriptor.
+    """
+
+    identifier = 'mt-rb912uag-2hpnd'
+    name = "RB912UAG-2HPnD"
+    manufacturer = "MikroTik"
+    url = 'https://mikrotik.com/product/RB912UAG-2HPnD'
+    architecture = 'ar71xx_mikrotik'
+    usb = True
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio"), [
+            cgm_protocols.IEEE80211BGN(
+                cgm_protocols.IEEE80211BGN.SHORT_GI_20,
+                cgm_protocols.IEEE80211BGN.SHORT_GI_40,
+                cgm_protocols.IEEE80211BGN.RX_STBC1,
+                cgm_protocols.IEEE80211BGN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna0")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = []
+    ports = [
+        cgm_devices.EthernetPort('lan0', "Lan0")
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'lan0': 'eth0',
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211',
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'nand-large',
+            'files': [
+                '*-ar71xx-mikrotik-nand-large-squashfs-sysupgrade.bin',
+                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
+            ]
+        }
+    }
+
+# Register the Mikrotik RB912 devices.
+cgm_base.register_device('lede', MikrotikRB912UAG_2HPnD)

--- a/nodewatcher/modules/devices/mikrotik/rb912.py
+++ b/nodewatcher/modules/devices/mikrotik/rb912.py
@@ -58,7 +58,6 @@ class MikrotikRB912UAG_2HPnD(cgm_devices.DeviceBase):
             'name': 'nand-large',
             'files': [
                 '*-ar71xx-mikrotik-nand-large-squashfs-sysupgrade.bin',
-                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
             ]
         }
     }

--- a/nodewatcher/modules/devices/mikrotik/rbmap.py
+++ b/nodewatcher/modules/devices/mikrotik/rbmap.py
@@ -1,0 +1,88 @@
+from django.utils.translation import ugettext_lazy as _
+
+from nodewatcher.core.generator.cgm import base as cgm_base, protocols as cgm_protocols, devices as cgm_devices
+
+
+class MikrotikRBmAP2nD(cgm_devices.DeviceBase):
+    """
+    Mikrotik RB mAP 2nD (mAP) device descriptor.
+    """
+
+    identifier = 'mt-rbmap-2nd'
+    name = "mAP (RBmAP2nD)"
+    manufacturer = "MikroTik"
+    url = 'https://mikrotik.com/product/RBmAP2nD'
+    architecture = 'ar71xx_mikrotik'
+    usb = True
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio"), [
+            cgm_protocols.IEEE80211BGN(
+                cgm_protocols.IEEE80211BGN.SHORT_GI_20,
+                cgm_protocols.IEEE80211BGN.SHORT_GI_40,
+                cgm_protocols.IEEE80211BGN.RX_STBC1,
+                cgm_protocols.IEEE80211BGN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna0")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = [
+        cgm_devices.Switch(
+            'sw0', "Switch0",
+            ports=[0, 1, 2],
+            cpu_port=0,
+            cpu_tagged=True,
+            vlans=4096,
+            configurable=True,
+            presets=[
+                cgm_devices.SwitchPreset('default', _("Default VLAN configuration"), vlans=[
+                    cgm_devices.SwitchVLANPreset(
+                        'wan0', "Wan0",
+                        vlan=2,
+                        ports=[0, 1],
+                    ),
+                    cgm_devices.SwitchVLANPreset(
+                        'lan0', "Lan0",
+                        vlan=1,
+                        ports=[0, 2],
+                    ),
+                ])
+            ]
+        ),
+    ]
+    ports = []
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='horizontal',
+            angle_horizontal=360,
+            angle_vertical=75,
+            gain=2,
+        )
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'sw0': cgm_devices.SwitchPortMap('switch0', vlans='eth0.{vlan}'),
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211',
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'rb-nor-flash-16M',
+            'files': [
+                '*-ar71xx-mikrotik-rb-nor-flash-16M-squashfs-sysupgrade.bin',
+                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
+            ]
+        }
+    }
+
+# Register the Mikrotik mAP devices.
+cgm_base.register_device('lede', MikrotikRBmAP2nD)

--- a/nodewatcher/modules/devices/mikrotik/rbmap.py
+++ b/nodewatcher/modules/devices/mikrotik/rbmap.py
@@ -79,7 +79,6 @@ class MikrotikRBmAP2nD(cgm_devices.DeviceBase):
             'name': 'rb-nor-flash-16M',
             'files': [
                 '*-ar71xx-mikrotik-rb-nor-flash-16M-squashfs-sysupgrade.bin',
-                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
             ]
         }
     }

--- a/nodewatcher/modules/devices/mikrotik/rbwap.py
+++ b/nodewatcher/modules/devices/mikrotik/rbwap.py
@@ -57,7 +57,6 @@ class MikrotikRBwAP2nD(cgm_devices.DeviceBase):
             'name': 'rb-nor-flash-16M',
             'files': [
                 '*-ar71xx-mikrotik-rb-nor-flash-16M-squashfs-sysupgrade.bin',
-                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
             ]
         }
     }

--- a/nodewatcher/modules/devices/mikrotik/rbwap.py
+++ b/nodewatcher/modules/devices/mikrotik/rbwap.py
@@ -1,0 +1,66 @@
+from django.utils.translation import ugettext_lazy as _
+
+from nodewatcher.core.generator.cgm import base as cgm_base, protocols as cgm_protocols, devices as cgm_devices
+
+
+class MikrotikRBwAP2nD(cgm_devices.DeviceBase):
+    """
+    Mikrotik RB wAP 2nD (wAP) device descriptor.
+    """
+
+    identifier = 'mt-rbwap-2nd'
+    name = "wAP (RBwAP2nD)"
+    manufacturer = "MikroTik"
+    url = 'https://mikrotik.com/product/RBwAP2nD'
+    architecture = 'ar71xx_mikrotik'
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio"), [
+            cgm_protocols.IEEE80211BGN(
+                cgm_protocols.IEEE80211BGN.SHORT_GI_20,
+                cgm_protocols.IEEE80211BGN.SHORT_GI_40,
+                cgm_protocols.IEEE80211BGN.RX_STBC1,
+                cgm_protocols.IEEE80211BGN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna0")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = []
+    ports = [
+        cgm_devices.EthernetPort('lan0', "Lan0")
+    ]
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='horizontal',
+            angle_horizontal=360,
+            angle_vertical=75,
+            gain=2,
+        )
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'lan0': 'eth0',
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211',
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'rb-nor-flash-16M',
+            'files': [
+                '*-ar71xx-mikrotik-rb-nor-flash-16M-squashfs-sysupgrade.bin',
+                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
+            ]
+        }
+    }
+
+# Register the Mikrotik wAP devices.
+cgm_base.register_device('lede', MikrotikRBwAP2nD)

--- a/nodewatcher/modules/devices/mikrotik/sxt.py
+++ b/nodewatcher/modules/devices/mikrotik/sxt.py
@@ -1,0 +1,66 @@
+from django.utils.translation import ugettext_lazy as _
+
+from nodewatcher.core.generator.cgm import base as cgm_base, protocols as cgm_protocols, devices as cgm_devices
+
+
+class MikrotikRBSXT5nDr2(cgm_devices.DeviceBase):
+    """
+    Mikrotik RB SXT5 nDr2 (SXT Lite 5) device descriptor.
+    """
+
+    identifier = 'mt-rbsxt-ndr2'
+    name = "RBSXT5nDr2 (SXT Lite 5)"
+    manufacturer = "MikroTik"
+    url = 'https://mikrotik.com/product/RBSXT5nDr2'
+    architecture = 'ar71xx_mikrotik'
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio"), [
+            cgm_protocols.IEEE80211AN(
+                cgm_protocols.IEEE80211AN.SHORT_GI_20,
+                cgm_protocols.IEEE80211AN.SHORT_GI_40,
+                cgm_protocols.IEEE80211AN.RX_STBC1,
+                cgm_protocols.IEEE80211AN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna0")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+    switches = []
+    ports = [
+        cgm_devices.EthernetPort('lan0', "Lan0")
+    ]
+    antennas = [
+        # TODO: This information is probably not correct
+        cgm_devices.InternalAntenna(
+            identifier='a1',
+            polarization='horizontal',
+            angle_horizontal=360,
+            angle_vertical=75,
+            gain=2,
+        )
+    ]
+    port_map = {
+        'openwrt': {
+            'wifi0': 'radio0',
+            'lan0': 'eth0',
+        }
+    }
+    drivers = {
+        'openwrt': {
+            'wifi0': 'mac80211',
+        }
+    }
+    profiles = {
+        'lede': {
+            'name': 'nand-large',
+            'files': [
+                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
+                '*-ar71xx-mikrotik-nand-large-squashfs-sysupgrade.bin'
+            ],
+        }
+    }
+
+# Register the Mikrotik SXT devices.
+cgm_base.register_device('lede', MikrotikRBSXT5nDr2)

--- a/nodewatcher/modules/devices/mikrotik/sxt.py
+++ b/nodewatcher/modules/devices/mikrotik/sxt.py
@@ -8,7 +8,7 @@ class MikrotikRBSXT5nDr2(cgm_devices.DeviceBase):
     Mikrotik RB SXT5 nDr2 (SXT Lite 5) device descriptor.
     """
 
-    identifier = 'mt-rbsxt-ndr2'
+    identifier = 'mt-rbsxt5-ndr2'
     name = "RBSXT5nDr2 (SXT Lite 5)"
     manufacturer = "MikroTik"
     url = 'https://mikrotik.com/product/RBSXT5nDr2'
@@ -62,5 +62,30 @@ class MikrotikRBSXT5nDr2(cgm_devices.DeviceBase):
         }
     }
 
+
+class MikrotikRBSXT2nDr2(MikrotikRBSXT5nDr2):
+    """
+    Mikrotik RB SXT2 nDr2 (SXT Lite 2) device descriptor.
+    """
+
+    identifier = 'mt-rbsxt2-ndr2'
+    name = "RBSXT2nDr2 (SXT Lite 2)"
+    url = 'https://mikrotik.com/product/RBSXT2nDr2'
+    radios = [
+        cgm_devices.IntegratedRadio('wifi0', _("Integrated wireless radio"), [
+            cgm_protocols.IEEE80211BGN(
+                cgm_protocols.IEEE80211BGN.SHORT_GI_20,
+                cgm_protocols.IEEE80211BGN.SHORT_GI_40,
+                cgm_protocols.IEEE80211BGN.RX_STBC1,
+                cgm_protocols.IEEE80211BGN.DSSS_CCK_40,
+            )
+        ], [
+            cgm_devices.AntennaConnector('a1', "Antenna0")
+        ], [
+            cgm_devices.DeviceRadio.MultipleSSID,
+        ])
+    ]
+
 # Register the Mikrotik SXT devices.
 cgm_base.register_device('lede', MikrotikRBSXT5nDr2)
+cgm_base.register_device('lede', MikrotikRBSXT2nDr2)

--- a/nodewatcher/modules/devices/mikrotik/sxt.py
+++ b/nodewatcher/modules/devices/mikrotik/sxt.py
@@ -56,7 +56,6 @@ class MikrotikRBSXT5nDr2(cgm_devices.DeviceBase):
         'lede': {
             'name': 'nand-large',
             'files': [
-                '*-ar71xx-mikrotik-vmlinux-initramfs.elf',
                 '*-ar71xx-mikrotik-nand-large-squashfs-sysupgrade.bin'
             ],
         }


### PR DESCRIPTION
This PR is to add multiple Mikrotik devices that I merged into LEDE, RB912, SXT Lites and LHG 5 which were already supported.

Builder for them is here:
https://hub.docker.com/r/otvorenamreza/lede-builder/tags/
Builder docker image name is vd1eff32_master_ar71xx_mikrotik_18_11_17

But again initramfs is not generated.
So current workaround since manually building imagebuilder using make menuconfig results in the same issue is to download https://downloads.lede-project.org/snapshots/targets/ar71xx/mikrotik/lede-ar71xx-mikrotik-vmlinux-initramfs.elf